### PR TITLE
Add support for custom paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ No dependencies required. Just Python 3.
 ```bash
 disk-usage-delta snapshot
 disk-usage-delta snapshot "before-cleanup"
+disk-usage-deta snapshot --path /home "home-directory"
+disk-usage-delta snapshot -p /var/log "logs"
 ```
 
 ### List all snapshots
@@ -38,10 +40,11 @@ disk-usage-delta list
 
 Output looks like:
 ```
-ID     Label                Timestamp                 Used           
-----------------------------------------------------------------------
-1      snapshot-1           2026-03-11T10:30:00       45.20 GB       
-2      before-cleanup       2026-03-11T14:00:00       52.10 GB       
+ID     Label                Path                      Timestamp                 Used
+-------------------------------------------------------------------------------------------------
+1      snapshot-1           /                         2026-03-11T10:30:00       45.20 GB
+2      before-cleanup       /                         2026-03-11T14:00:00       52.10 GB
+3      home-directory       /home                     2026-03-11T15:00:00       12.50 GB
 ```
 
 ### Compare two snapshots
@@ -83,8 +86,23 @@ disk-usage-delta snapshot "after-apt-upgrade"
 disk-usage-delta delta 1 2
 ```
 
+## Tracking Specific Paths
+
+By default, snapshots track the root filesystem (`/`). You can track any path:
+
+```bash
+# Track your home directory
+disk-usage-delta snapshot -p /home "home-before-install"
+
+# Track a specific project directory
+disk-usage-delta snapshot -p /projects/myproject "before-build"
+
+# Track logs directory
+disk-usage-delta snapshot -p /var/log "logs-before-rotation"
+```
+
 ## Notes
 
-- Only tracks the root filesystem (`/`)
 - Uses `os.statvfs` so it works on Linux and macOS
 - No network calls, no telemetry, nothing fancy
+- When comparing snapshots with `delta`, a warning is shown if the paths differ

--- a/disk_usage_delta.py
+++ b/disk_usage_delta.py
@@ -69,32 +69,34 @@ def format_size(bytes_value):
     return f"{bytes_value:.2f} PB"
 
 
-def take_snapshot(label=None):
+def take_snapshot(label=None, path="/"):
     """Take a snapshot of current disk usage."""
     ensure_data_dir()
     snapshots = load_snapshots()
-    
+
     timestamp = datetime.now().isoformat()
     if not label:
         label = f"snapshot-{len(snapshots) + 1}"
-    
-    root_usage = get_disk_usage("/")
-    if not root_usage:
+
+    usage = get_disk_usage(path)
+    if not usage:
         print("Failed to get disk usage", file=sys.stderr)
         return False
-    
+
     snapshot = {
         "id": len(snapshots) + 1,
         "label": label,
         "timestamp": timestamp,
-        "usage": root_usage,
+        "path": str(path),
+        "usage": usage,
     }
-    
+
     snapshots.append(snapshot)
     save_snapshots(snapshots)
     print(f"Snapshot #{snapshot['id']} saved: {label}")
+    print(f"  Path: {str(path)}")
     print(f"  Time: {timestamp}")
-    print(f"  Used: {format_size(root_usage['used'])} / {format_size(root_usage['total'])} ({root_usage['percent_used']}%)")
+    print(f"  Used: {format_size(usage['used'])} / {format_size(usage['total'])} ({usage['percent_used']}%)")
     return True
 
 
@@ -104,13 +106,14 @@ def list_snapshots():
     if not snapshots:
         print("No snapshots found. Take one with: disk-usage-delta snapshot")
         return
-    
-    print(f"{'ID':<6} {'Label':<20} {'Timestamp':<25} {'Used':<15}")
-    print("-" * 70)
+
+    print(f"{'ID':<6} {'Label':<20} {'Path':<25} {'Timestamp':<25} {'Used':<15}")
+    print("-" * 95)
     for snap in snapshots:
         usage = snap.get("usage", {})
         used = format_size(usage.get("used", 0))
-        print(f"{snap['id']:<6} {snap['label']:<20} {snap['timestamp']:<25} {used:<15}")
+        path = snap.get("path", "/")
+        print(f"{snap['id']:<6} {snap['label']:<20} {path:<25} {snap['timestamp']:<25} {used:<15}")
 
 
 def show_delta(id1, id2):
@@ -119,45 +122,51 @@ def show_delta(id1, id2):
     if not snapshots:
         print("No snapshots found", file=sys.stderr)
         return
-    
+
     snap1 = next((s for s in snapshots if s["id"] == id1), None)
     snap2 = next((s for s in snapshots if s["id"] == id2), None)
-    
+
     if not snap1:
         print(f"Snapshot #{id1} not found", file=sys.stderr)
         return
     if not snap2:
         print(f"Snapshot #{id2} not found", file=sys.stderr)
         return
-    
+
     usage1 = snap1.get("usage", {})
     usage2 = snap2.get("usage", {})
-    
+    path1 = snap1.get("path", "/")
+    path2 = snap2.get("path", "/")
+
+    if path1 != path2:
+        print(f"Warning: Comparing different paths: {path1} vs {path2}", file=sys.stderr)
+
     used_delta = usage2.get("used", 0) - usage1.get("used", 0)
     free_delta = usage2.get("free", 0) - usage1.get("free", 0)
     percent_delta = usage2.get("percent_used", 0) - usage1.get("percent_used", 0)
-    
+
     print(f"Disk Usage Delta: {snap1['label']} -> {snap2['label']}")
+    print(f"Path: {path2}")
     print(f"Time range: {snap1['timestamp']} to {snap2['timestamp']}")
     print()
     print(f"{'Metric':<20} {'Before':<15} {'After':<15} {'Change':<15}")
     print("-" * 65)
-    
+
     before_used = format_size(usage1.get("used", 0))
     after_used = format_size(usage2.get("used", 0))
     change_used = f"{'+' if used_delta >= 0 else ''}{format_size(used_delta)}"
     print(f"{'Used':<20} {before_used:<15} {after_used:<15} {change_used:<15}")
-    
+
     before_free = format_size(usage1.get("free", 0))
     after_free = format_size(usage2.get("free", 0))
     change_free = f"{'+' if free_delta >= 0 else ''}{format_size(free_delta)}"
     print(f"{'Free':<20} {before_free:<15} {after_free:<15} {change_free:<15}")
-    
+
     before_pct = usage1.get("percent_used", 0)
     after_pct = usage2.get("percent_used", 0)
     change_pct = f"{'+' if percent_delta >= 0 else ''}{percent_delta:.2f}%"
     print(f"{'Percent Used':<20} {before_pct:<15.2f} {after_pct:<15.2f} {change_pct:<15}")
-    
+
     if used_delta > 0:
         print(f"\nWarning: Disk usage increased by {format_size(used_delta)}")
     elif used_delta < 0:
@@ -190,11 +199,13 @@ def show_latest():
     if not snapshots:
         print("No snapshots found")
         return
-    
+
     latest = snapshots[-1]
     usage = latest.get("usage", {})
-    
+    path = latest.get("path", "/")
+
     print(f"Latest Snapshot: {latest['label']}")
+    print(f"  Path: {path}")
     print(f"  Time: {latest['timestamp']}")
     print(f"  Total: {format_size(usage.get('total', 0))}")
     print(f"  Used: {format_size(usage.get('used', 0))}")
@@ -209,22 +220,34 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
-    
-    subparsers.add_parser("snapshot", help="Take a disk usage snapshot")
+
+    snapshot_parser = subparsers.add_parser("snapshot", help="Take a disk usage snapshot")
+    snapshot_parser.add_argument(
+        "-p", "--path",
+        default="/",
+        help="Path to track (default: /)",
+    )
+    snapshot_parser.add_argument(
+        "label",
+        nargs="?",
+        default=None,
+        help="Optional label for the snapshot",
+    )
+
     subparsers.add_parser("list", help="List all snapshots")
     subparsers.add_parser("latest", help="Show the latest snapshot")
-    
+
     delta_parser = subparsers.add_parser("delta", help="Show delta between snapshots")
     delta_parser.add_argument("before", type=int, help="Snapshot ID to compare from")
     delta_parser.add_argument("after", type=int, help="Snapshot ID to compare to")
-    
+
     delete_parser = subparsers.add_parser("delete", help="Delete a snapshot")
     delete_parser.add_argument("id", type=int, help="Snapshot ID to delete")
-    
+
     args = parser.parse_args()
-    
+
     if args.command == "snapshot":
-        take_snapshot()
+        take_snapshot(label=args.label, path=args.path)
     elif args.command == "list":
         list_snapshots()
     elif args.command == "latest":


### PR DESCRIPTION
Hey, just shipped the ability to track specific paths instead of being stuck with root `/`! Added a `--path` / `-p` flag to the snapshot command so you can now monitor your home directory, project folders, or wherever you need. Also updated the list and delta views to show which path each snapshot is tracking, plus a heads-up warning if you compare snapshots from different paths. closes #1